### PR TITLE
Add ingress to heritage-dev app & data subnets and CHS dev app subnets

### DIFF
--- a/groups/chips-dba-dev/data.tf
+++ b/groups/chips-dba-dev/data.tf
@@ -52,6 +52,18 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "dev_data_cidrs" {
+  path = "aws-accounts/network/ch-development/heritage/data-subnets"
+}
+
+data "vault_generic_secret" "dev_application_cidrs" {
+  path = "aws-accounts/network/ch-development/heritage/application-subnets"
+}
+
+data "vault_generic_secret" "chs_application_cidrs" {
+  path = "aws-accounts/network/heritage-development/chs/application-subnets"
+}
+
 data "vault_generic_secret" "ec2_data" {
   path = "applications/${var.aws_account}-${var.aws_region}/${var.application}/db/ec2"
 }

--- a/groups/chips-dba-dev/locals.tf
+++ b/groups/chips-dba-dev/locals.tf
@@ -3,6 +3,9 @@
 # ------------------------------------------------------------------------
 locals {
   internal_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
+  dev_data_cidrs = values(data.vault_generic_secret.dev_data_cidrs.data)
+  dev_application_cidrs = values(data.vault_generic_secret.dev_application_cidrs.data)
+  chs_application_cidrs = values(data.vault_generic_secret.chs_application_cidrs.data)
 
   data_subnet_az_map = { for id, map in data.aws_subnet.data_subnets : map["availability_zone"] => map }
 
@@ -28,7 +31,7 @@ locals {
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
-  oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle)
+  oracle_allowed_ranges = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_oracle, local.dev_data_cidrs, local.dev_application_cidrs, local.chs_application_cidrs)
   ssh_allowed_ranges    = concat(local.internal_cidrs, var.vpc_sg_cidr_blocks_ssh)
 
   iscsi_initiator_names = split(",", local.ec2_data["iscsi-initiator-names"])


### PR DESCRIPTION

Allow access from the Weblogic app tier, RDS iProcess/Staffware instance on heritage-development, and CHS application subnets on ch-development to the CHIPS dev OLTP DB on heritage-staging.